### PR TITLE
Fix exception on host application startup for Amazon Linux 2

### DIFF
--- a/projects/InvokeChat/InvokeChat.Backend.Host.Aws/Program.cs
+++ b/projects/InvokeChat/InvokeChat.Backend.Host.Aws/Program.cs
@@ -29,7 +29,7 @@ public class Program
     {
         var awsManager = new AwsManager();
         awsManager.Start(LogFile);
-        Console.ReadKey();
+        Thread.Sleep(Timeout.Infinite);
         return 0;
     }
 


### PR DESCRIPTION
`Console.ReadKey` is not supported by Amazon Linux 2.
This causes immediate program termination. Then GameLift tries to restart the application many times.

![image](https://user-images.githubusercontent.com/23500895/174313865-3dadb57f-fb88-4d5a-af95-df5637676624.png)

P.S. `Console.ReadLine` doesn't help either. I guess there is always a lookahead symbol in stdin, so application finishes immediately without an error log. Thread.Sleep works fine.

